### PR TITLE
imp: remove importer from top level lib exports

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,8 +50,6 @@
         inherit attrs lists modules importers generators;
         inherit (lib)
           mkFlake
-          pathsIn
-          importHosts
           mkDeployNodes
           mkHomeConfigurations;
       };


### PR DESCRIPTION
Importers are auxiliary functions of this library. It feels inconsistent when
they have the same visibility of primary (builder) functions.